### PR TITLE
fix(ci): give CodeQL a node to extract TypeScript with

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,6 +32,16 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
+      # CodeQL's TypeScript extractor shells out to `node`, and the self-hosted
+      # runner image deliberately ships none -- the runner's own copy lives in
+      # externals/ and is not on PATH. Without this the analysis fails with
+      # "Could not start Node.js. It is required for TypeScript extraction."
+      - name: Setup Node.js
+        id: setup-node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+
       - name: Initialize CodeQL
         id: initialize
         uses: github/codeql-action/init@v3


### PR DESCRIPTION
The self-hosted runner image was replaced with a minimal one (10.5GB → ~1GB) that ships no language runtimes.

JS actions are unaffected — they use the runner's bundled node in `externals/` — but CodeQL's TypeScript extractor shells out to `node` on PATH:

```
Could not start Node.js. It is required for TypeScript extraction.
Please install Node.js and ensure 'node' is on the PATH.
```

Adds `actions/setup-node` before `codeql-action/init`, using `.node-version` — the same way `ci.yml` and `check-dist.yml` in this repo already set node up.

A scan of all 129 org repos found only this repo and the other of the pair affected.